### PR TITLE
Removes jshint from scripts.js because it is no longer being used, nor i...

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -3,7 +3,6 @@ var config = require('./config.js');
 
 var eslint = require('gulp-eslint');
 var uglify = require('gulp-uglify');
-var jshint = require('gulp-jshint');
 var source = require('vinyl-source-stream');
 var to5ify = require("babelify");
 var watchify = require('watchify');


### PR DESCRIPTION
...s it included in package.json
